### PR TITLE
Fix a typo that prevents the SM4 event xml from closing correctly.

### DIFF
--- a/apps/scwfparam/wfparam.cpp
+++ b/apps/scwfparam/wfparam.cpp
@@ -2524,7 +2524,7 @@ void WFParam::collectResults() {
 					    << " minute=\"" << min << "\" "
 					    << " second=\"" << sec << "\" timezone=\"GMT\"";
 				else
-					*os << " time=\"" << org->time().value().iso();
+					*os << " time=\"" << org->time().value().iso() << "\"";
 
 				*os << " locstring=\"" << locstring << "\""
 				    << " created=\"" << Core::Time::GMT().seconds() << "\"/>"


### PR DESCRIPTION
The time attribute does not have a closing quotation marks (").