### PR TITLE
[screloc]: store triggering origin in comment

### DIFF
--- a/apps/screloc/descriptions/screloc.xml
+++ b/apps/screloc/descriptions/screloc.xml
@@ -45,6 +45,12 @@
 					during the relocation process as well.
 					</description>
 				</parameter>
+				<parameter name="storeSourceOriginID" type="boolean" default="false">
+					<description>
+						Whether to store the ID of the input origin as comment in the
+						relocated origin or not.
+					</description>
+				</parameter>  
 				<parameter name="originIDSuffix" type="string">
 					<description>
 					Suffix appended to the publicID of the origin to be relocated

--- a/apps/screloc/main.cpp
+++ b/apps/screloc/main.cpp
@@ -63,6 +63,7 @@ class Reloc : public Client::Application {
 			_originEvaluationMode = "AUTOMATIC";
 			_adoptFixedDepth = false;
 			_repeatedRelocationCount = 1;
+			_storeSourceOriginID = false;
 		}
 
 

--- a/apps/screloc/main.cpp
+++ b/apps/screloc/main.cpp
@@ -132,6 +132,9 @@ class Reloc : public Client::Application {
 			try { _originIDSuffix = configGetString("reloc.originIDSuffix"); }
 			catch ( ... ) {}
 
+			try { _storeSourceOriginID = configGetBool("reloc.storeSourceOriginID"); }
+			catch ( ... ) {}
+
 			if ( !_epFile.empty() )
 				setMessagingEnabled(false);
 
@@ -503,6 +506,15 @@ class Reloc : public Client::Application {
 
 				ci->setAgencyID(agencyID());
 				ci->setAuthor(author());
+
+				// keep track of the triggering origin of this relocation
+				if (_storeSourceOriginID ) {
+					DataModel::CommentPtr comment = new DataModel::Comment();
+					comment->setId("relocation::sourceOrigin");
+					comment->setText(org->publicID());
+					comment->setCreationInfo(*ci);
+					newOrg->add(comment.get());
+				}
 			}
 
 			if ( commandline().hasOption("measure-relocation-time") ) {
@@ -571,6 +583,7 @@ class Reloc : public Client::Application {
 		ObjectLog                 *_inputOrgs;
 		ObjectLog                 *_outputOrgs;
 		bool                       _useWeight;
+		bool                       _storeSourceOriginID;
 		std::string                _originEvaluationMode;
 		std::string                _epFile;
 		size_t                     _repeatedRelocationCount;


### PR DESCRIPTION
I would like to propose this change that has been in my mind for a while now. I believe it is good to keep track of the triggering origin of a relocation. This is very useful for troubleshooting and  when performing statistical analysis on the relocations. The triggering origin can be stored as comment in the relocated origin.

@gempa-jabe Do you see any issue with this change?