### PR TITLE
[scwfparam] Allow to output any spectral values with ShakeMap >= 4

### DIFF
--- a/apps/scwfparam/descriptions/scwfparam.xml
+++ b/apps/scwfparam/descriptions/scwfparam.xml
@@ -382,6 +382,14 @@
 							Enables/disables ShakeMap XML output.
 							</description>
 						</parameter>
+						<parameter name="pgm" type="list:string" default="pga, pgv, psa03, psa10, psa30">
+							<description>
+							Define a list of pg values to be forwarded to
+							ShakeMap in version 4 or later.
+							The period xx in psa must be in the list of
+							naturalPeriods and must not exceed 9.9s.
+							</description>
+						</parameter>
 						<parameter name="path" type="string" default="@LOGDIR@/shakemaps">
 							<description>
 							Specifies the ShakeMap XML output path. This is only used if

--- a/apps/scwfparam/util.h
+++ b/apps/scwfparam/util.h
@@ -70,6 +70,7 @@ struct PGAVResult {
 	std::string      filename;
 
 	Processing::PGAV::ResponseSpectra responseSpectra;
+	const Processing::PGAV::ResponseSpectrum *responseSpectrum;
 };
 
 

--- a/apps/scwfparam/wfparam.h
+++ b/apps/scwfparam/wfparam.h
@@ -165,13 +165,21 @@ class WFParam : public Application {
 			std::string eventParameterFile;
 
 			bool        enableShortEventID;
-			bool        enableShakeMapXMLOutput;
-			std::string shakeMapOutputScript;
-			std::string shakeMapOutputPath;
-			bool        shakeMapOutputScriptWait;
-			bool        shakeMapOutputSC3EventID;
-			bool        shakeMapOutputRegionName;
-			std::string shakeMapXMLEncoding;
+
+			struct {
+				struct {
+					bool                     enable;
+					std::vector<std::string> pgm;
+					std::string              script;
+					std::string              path;
+					bool                     scriptWait;
+					bool                     SC3EventID;
+					bool                     regionName;
+					std::string              XMLEncoding;
+					bool                     useMaximumOfHorizontals;
+					int                      version;
+				} output;
+			}           shakeMap;
 
 			bool        enableMessagingOutput;
 
@@ -192,7 +200,6 @@ class WFParam : public Application {
 			int         PDorder;
 			FilterFreqs PDfilter;
 
-			bool        useMaximumOfHorizontals;
 			bool        offline;
 			bool        force;
 			bool        forceShakemap;
@@ -209,7 +216,6 @@ class WFParam : public Application {
 			double      magnitudeTolerance;
 			bool        dumpRecords;
 
-			int         shakemapTargetVersion;
 			std::string organization;
 
 			// Cron options
@@ -272,9 +278,10 @@ class WFParam : public Application {
 			bool hasBeenProcessed(DataModel::Stream *) const;
 		};
 
-		typedef std::list<ProcessPtr>                            ProcessQueue;
-		typedef std::map<std::string, ProcessPtr>                Processes;
-		typedef std::set<DataModel::EventPtr>                    Todos;
+		using ProcessQueue = std::list<ProcessPtr>;
+		using Processes    = std::map<std::string, ProcessPtr>;
+		using Todos        = std::set<DataModel::EventPtr>;
+		using PeriodID     = std::pair<std::string, double>;
 
 		std::set<std::string>      _processedEvents;
 
@@ -308,6 +315,9 @@ class WFParam : public Application {
 		FilterFreqs                _filter;
 		int                        _cronCounter;
 		int                        _acquisitionTimeout;
+		bool                       _wantShakeMapPGA;
+		bool                       _wantShakeMapPGV;
+		std::vector<PeriodID>      _wantShakeMapPSAPeriods;
 
 		Util::StopWatch            _acquisitionTimer;
 		Util::StopWatch            _noDataTimer;


### PR DESCRIPTION
Add configuration `wfparam.output.shakeMap.pgm` to define the spectral values exported to ShakeMap >= 4.

```
wfparam.output.shakeMap.pgm = pga, pgv, psa03, psa10, psa30
```

is the default.