### PR TITLE
[screloc]

### DIFF
--- a/apps/screloc/descriptions/screloc.xml
+++ b/apps/screloc/descriptions/screloc.xml
@@ -135,6 +135,12 @@
 			</group>
 
 			<group name="Mode">
+				<option long-flag="dump">
+					<description>
+					Dump processed origins as XML to stdout. Use in combination
+					with -O.
+					</description>
+				</option>
 				<option long-flag="test">
 					<description>
 					Test mode, do not send any message.
@@ -143,32 +149,32 @@
 			</group>
 
 			<group name="Input">
+				<option long-flag="locator" argument="arg" param-ref="reloc.locator">
+				</option>
+				<option long-flag="profile" argument="arg" param-ref="reloc.profile">
+				</option>
+				<option long-flag="ep" argument="arg">
+					<description>
+					Event parameters XML file for offline processing of all
+					contained origins. This option should not be mixed with
+					--dump.
+					</description>
+				</option>
 				<option flag="O" long-flag="origin-id" argument="arg">
 					<description>
 					Reprocess the origin and send a message unless test mode is
 					activated.
 					</description>
 				</option>
-				<option long-flag="locator" argument="arg">
-					<description>The locator type to use.</description>
-				</option>
-				<option long-flag="use-weight" argument="arg" default="0">
-					<description>Use current picks weight.</description>
+				<option long-flag="use-weight"  param-ref="reloc.useWeight" default="0">
 				</option>
 				<option long-flag="streams-set-unused" param-ref="picks.streamsSetUnused" argument="arg" type="list:string">
-				</option>
-				<option long-flag="evaluation-mode" argument="arg">
 					<description>
-					Set origin evaluation mode: &quot;AUTOMATIC&quot; or
-					&quot;MANUAL&quot;
-					</description>
-				</option>
-				<option long-flag="ep" argument="file">
-					<description>
-					Defines an event parameters XML file to be read and processed. This
-					implies offline mode and only processes all origins contained
-					in that file. Each relocated origin is appended to the list
-					of origins unless --replace is given.
+					List of streams from which picks are set to unsed by their
+					referencing arrivals before locating. The concerned arrivals
+					are kept but the picks will not be used for locating.
+					Streams take the format NET.STA.LOC.CHA. Wildcards * and ?
+					are supported.
 					</description>
 				</option>
 				<option long-flag="replace">
@@ -180,9 +186,29 @@
 					</description>
 				</option>
 			</group>
+			<group name="Output">
+				<option long-flag="evaluation-mode">
+					<description>
+					Evaluation mode of the new origin (AUTOMATIC or MANUAL).
+					</description>
+				</option>
+				<option flag="f" long-flag="formatted">
+					<description>
+					Use formatted XML output. Otherwise XML is unformatted.
+					</description>
+				</option>
+				<option long-flag="origin-id-suffix">
+					<description>
+					Create origin ID from that of the input origin plus the
+					specfied suffix.
+					</description>
+				</option>
+			</group>
 			<group name="Profiling">
 				<option long-flag="measure-relocation-time">
-					<description>Measure the time spent in a single relocation</description>
+					<description>
+					Measure the time spent in a single relocation
+					</description>
 				</option>
 				<option long-flag="repeated-relocations" argument="arg">
 					<description>

--- a/apps/screloc/main.cpp
+++ b/apps/screloc/main.cpp
@@ -67,18 +67,25 @@ class Reloc : public Client::Application {
 	protected:
 		void createCommandLineDescription() override {
 			commandline().addGroup("Mode");
+			commandline().addOption("Mode", "dump",
+			                        "Dump processed origins as XML to stdout."
+			                        "Use in combination with -O");
 			commandline().addOption("Mode", "test",
 			                        "Test mode, do not send any message.");
-			commandline().addOption("Mode", "dump",
-			                        "Dump processed origins as XML to stdout.");
+
 			commandline().addGroup("Input");
-			commandline().addOption("Input", "origin-id,O",
-			                        "Reprocess the origin and send a message.",
-			                        &_originIDs);
 			commandline().addOption("Input", "locator",
 			                        "The locator type to use.", &_locatorType, false);
 			commandline().addOption("Input", "profile",
 			                        "The locator profile to use.", &_locatorProfile, false);
+			commandline().addOption("Input", "ep",
+			                        "Event parameters XML file for offline "
+			                        "processing of all contained origins. This "
+			                        "option should not be mixed with --dump.",
+			                        &_epFile);
+			commandline().addOption("Input", "origin-id,O",
+			                        "Reprocess the origin and send a message.",
+			                        &_originIDs);
 			commandline().addOption("Input", "use-weight",
 			                        "Use current picks weight.", &_useWeight, true);
 			commandline().addOption("Input", "streams-set-unused",
@@ -90,11 +97,6 @@ class Reloc : public Client::Application {
 			                        "NET.STA.LOC.CHA. Wildcards * and ? are "
 			                        "supported.",
 			                        &_pickStreamsSetUnused);
-			commandline().addOption("Input", "ep",
-			                        "Event parameters XML file for offline "
-			                        "processing of all contained origins. This "
-			                        "option should not be mixed with --dump.",
-			                        &_epFile);
 			commandline().addOption("Input", "replace",
 			                        "Used in combination with --ep and defines "
 			                        "if origins are to be replaced by their "
@@ -103,14 +105,19 @@ class Reloc : public Client::Application {
 			                        "Used in combination with --replace/--ep "
 			                        "and drops from the output the origins for "
 			                        "which the relocation failed.");
+
 			commandline().addGroup("Output");
+			commandline().addOption("Output", "evaluation-mode",
+			                        "Evaluation mode of the new origin (AUTOMATIC or MANUAL).",
+			                        &_originEvaluationMode, true);
+			commandline().addOption("Output", "formatted,f",
+			                        "Use formatted XML output. Otherwise XML "
+			                        "is unformatted.");
 			commandline().addOption("Output", "origin-id-suffix",
 			                        "Create origin ID from that of the input "
 			                        "origin plus the specfied suffix.",
 			                        &_originIDSuffix);
-			commandline().addOption("Output", "evaluation-mode",
-			                        "Evaluation mode of the new origin (AUTOMATIC or MANUAL).",
-			                        &_originEvaluationMode, true);
+
 			commandline().addGroup("Profiling");
 			commandline().addOption("Profiling", "measure-relocation-time",
 			                        "Measure and log the time it takes to run each relocation.");
@@ -366,7 +373,7 @@ class Reloc : public Client::Application {
 				              processed, numRelocated);
 
 				ar.create("-");
-				ar.setFormattedOutput(true);
+				ar.setFormattedOutput(commandline().hasOption("formatted"));
 				ar << ep;
 				ar.close();
 
@@ -658,7 +665,7 @@ class Reloc : public Client::Application {
 				}
 
 				IO::XMLArchive ar;
-				ar.setFormattedOutput(true);
+				ar.setFormattedOutput(commandline().hasOption("formatted"));
 				ar.create("-");
 				ar << ep;
 				ar.close();


### PR DESCRIPTION
    - Add/update examples in documentation
    - Add option --formatted for printing formatted XML to stdout. The default is changed unformatted for reducing size of XML output.
    - Add missing command-line parameters to description XML.