### PR TITLE
[scwfparam] Add support for custom list of periods

### DIFF
--- a/apps/scwfparam/descriptions/scwfparam.xml
+++ b/apps/scwfparam/descriptions/scwfparam.xml
@@ -114,7 +114,9 @@
 					<description>
 					Specifies the number of natural periods for computation of the
 					relative displacement elastic response spectrum between Tmin and Tmax.
-					If fixed is given then a fixed list of periods is used.
+					If &quot;fixed&quot; is given then a fixed list of periods is used. If
+					&quot;custom&quot; is defined then a custom list of periods
+					will be used. This list must be configured with &quot;customPeriods&quot;.
 					</description>
 				</parameter>
 				<group name="naturalPeriods">
@@ -126,6 +128,13 @@
 						</description>
 					</parameter>
 				</group>
+				<parameter name="customPeriods" type="list:double" unit="s">
+					<description>
+					A list of periods to be used for computation of the
+					relative displacement elastic response spectrum. This list
+					will only be in effect if &quot;naturalPeriods = custom&quot;.
+					</description>
+				</parameter>
 				<parameter name="Tmin" type="double" unit="s" default="0">
 					<description>
 					Specifies the minimum period (Tmin) in seconds for computation of the

--- a/apps/scwfparam/processors/pgav.h
+++ b/apps/scwfparam/processors/pgav.h
@@ -68,6 +68,7 @@ class PGAV : public TimeWindowProcessor {
 			double  durationScale;
 
 			std::vector<double> dampings;
+			std::vector<double> customPeriods;
 			int     naturalPeriods;
 			bool    naturalPeriodsLog;
 			double  Tmin;
@@ -108,6 +109,8 @@ class PGAV : public TimeWindowProcessor {
 		                                   int nPeriods,
 		                                   double Tmin, double Tmax,
 		                                   bool logarithmicSpacing);
+
+		void setCustomPeriods(const std::vector<double> &periods);
 
 		void setAftershockRemovalEnabled(bool);
 		void setPreEventCutOffEnabled(bool);

--- a/apps/scwfparam/wfparam.h
+++ b/apps/scwfparam/wfparam.h
@@ -148,6 +148,7 @@ class WFParam : public Application {
 			double      durationScale;
 
 			std::vector<double> dampings;
+			std::vector<double> customPeriods;
 			std::string naturalPeriodsStr;
 			int         naturalPeriods;
 			bool        naturalPeriodsLog;


### PR DESCRIPTION
This PR adds support for a custom list of periods to be used for computation of the relative displacement elastic response spectrum. The configuration boils down to:

```
wfparam.naturalPeriods = custom
wfparam.customPeriods = 0.1, 0.3, 1
```